### PR TITLE
Fix exception with Lexicon 3.x

### DIFF
--- a/certbot_dns_namecheap/dns_namecheap.py
+++ b/certbot_dns_namecheap/dns_namecheap.py
@@ -67,7 +67,8 @@ class Authenticator(dns_common.DNSAuthenticator):
 
 class ncProvider(namecheap.Provider):
     def authenticate(self):
-        self.domain = self.options['domain']
+        if hasattr(self, 'options'):  # Only for Lexicon 2.x
+            self.domain = self.options['domain']
         super(ncProvider, self).authenticate()
 
 class _NamecheapLexiconClient(dns_common_lexicon.LexiconClient):


### PR DESCRIPTION
When using Lexicon 3.x, an exception is raised since `ncProvider` doesn't have an `option` attribute. This PR aims to fix this problem.